### PR TITLE
Utilizing User Signals for Personalized News Curation

### DIFF
--- a/StalkFinance/Base.lproj/Main.storyboard
+++ b/StalkFinance/Base.lproj/Main.storyboard
@@ -1312,7 +1312,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="yRR-uS-qpF"/>
+        <segue reference="mLT-le-pxc"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="StalkFinanceBlackYellow" width="1175" height="475"/>

--- a/StalkFinance/Base.lproj/Main.storyboard
+++ b/StalkFinance/Base.lproj/Main.storyboard
@@ -319,6 +319,7 @@
                                             <outlet property="conversionId" destination="jMj-fz-Jua" id="o8k-fZ-InC"/>
                                             <outlet property="currentPrice" destination="Sq5-yH-c0M" id="idg-s0-cDN"/>
                                             <outlet property="ticker" destination="fco-9v-mkh" id="3lv-eR-iUP"/>
+                                            <segue destination="HI4-qS-WYC" kind="presentation" identifier="watchlistToDetails" id="cWF-r0-OGG"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>
@@ -341,7 +342,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9uc-Mw-JXM" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1944.9275362318842" y="841.74107142857144"/>
+            <point key="canvasLocation" x="2132" y="814"/>
         </scene>
         <!--Crypto-->
         <scene sceneID="NWJ-lL-DzW">
@@ -681,7 +682,7 @@
                         <viewLayoutGuide key="safeArea" id="oai-df-3RD"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Search" selectedImage="magnifyingglass.circle" catalog="system" id="3Bo-om-AdG"/>
+                    <tabBarItem key="tabBarItem" title="Search" image="magnifyingglass.circle.fill" catalog="system" id="3Bo-om-AdG"/>
                     <navigationItem key="navigationItem" id="Ock-X0-bSQ"/>
                     <connections>
                         <outlet property="searchBar" destination="4x4-x5-Mln" id="FP9-9e-b54"/>
@@ -706,8 +707,8 @@
                         <segue destination="aeT-eV-mUN" kind="relationship" relationship="viewControllers" id="eW2-Yj-5uq"/>
                         <segue destination="xVk-df-Qdq" kind="relationship" relationship="viewControllers" id="FsQ-V9-jxW"/>
                         <segue destination="WK5-DA-mpG" kind="relationship" relationship="viewControllers" id="qKj-T4-dqm"/>
-                        <segue destination="YHS-pn-9yW" kind="relationship" relationship="viewControllers" id="m1I-qO-sRl"/>
                         <segue destination="kBm-Ca-qg6" kind="relationship" relationship="viewControllers" id="w9y-hy-wes"/>
+                        <segue destination="YHS-pn-9yW" kind="relationship" relationship="viewControllers" id="m1I-qO-sRl"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Gfk-TK-kbL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -1304,7 +1305,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="yRR-uS-qpF"/>
+        <segue reference="cWF-r0-OGG"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="StalkFinanceBlackYellow" width="1175" height="475"/>
@@ -1312,11 +1313,14 @@
         <image name="chart.line.uptrend.xyaxis" catalog="system" width="128" height="101"/>
         <image name="eyes" catalog="system" width="128" height="99"/>
         <image name="lock.icloud.fill" catalog="system" width="128" height="88"/>
-        <image name="magnifyingglass.circle" catalog="system" width="128" height="121"/>
+        <image name="magnifyingglass.circle.fill" catalog="system" width="128" height="121"/>
         <image name="newspaper.fill" catalog="system" width="128" height="111"/>
         <image name="xmark.circle.fill" catalog="system" width="128" height="121"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGreenColor">
             <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/StalkFinance/Base.lproj/Main.storyboard
+++ b/StalkFinance/Base.lproj/Main.storyboard
@@ -609,12 +609,12 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <searchBar contentMode="redraw" fixedFrame="YES" placeholder="Search All Stocks &amp; Crypto" translatesAutoresizingMaskIntoConstraints="NO" id="4x4-x5-Mln">
-                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="80" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="295-sa-30f">
-                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
+                                <rect key="frame" x="0.0" y="138" width="414" height="758"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
@@ -678,6 +678,13 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Search" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KEB-TV-72Z">
+                                <rect key="frame" x="12" y="35" width="134" height="45"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="36"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="oai-df-3RD"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -1305,7 +1312,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="cWF-r0-OGG"/>
+        <segue reference="yRR-uS-qpF"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="StalkFinanceBlackYellow" width="1175" height="475"/>

--- a/ViewControllers/NewsFeedViewController.m
+++ b/ViewControllers/NewsFeedViewController.m
@@ -37,7 +37,6 @@
     self.newsFeedTableView.dataSource = self;
     self.newsFeedTableView.delegate = self;
     [self fetchNews];
-    //[self updateToPersonalizedNews];
     self.refresh = [[UIRefreshControl alloc] init];
     [self.refresh setTintColor:[UIColor whiteColor]];
     [self.refresh addTarget:self action:@selector(updateToPersonalizedNews) forControlEvents:UIControlEventValueChanged];
@@ -115,7 +114,5 @@
 - (NSInteger)tableView:(nonnull UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     return self.newsArray.count;
 }
-
-
 
 @end

--- a/ViewControllers/NewsFeedViewController.m
+++ b/ViewControllers/NewsFeedViewController.m
@@ -80,10 +80,10 @@
         }
         NSString *mostSpentTimeKey;
         NSString *key;
-        if (timeSpentTicker.count > 0){
+        if (timeSpentTicker.count > 0) {
             mostSpentTimeKey = [timeSpentTicker objectAtIndex:(NSInteger)largestIndex];
         }
-        if ([likedKeywords containsObject:mostSpentTimeKey]){
+        if ([likedKeywords containsObject:mostSpentTimeKey]) {
             if ([searchedKeywords containsObject:mostSpentTimeKey]) {
                 key = mostSpentTimeKey;
             }

--- a/ViewControllers/NewsFeedViewController.m
+++ b/ViewControllers/NewsFeedViewController.m
@@ -16,7 +16,6 @@
 
 @import SafariServices;
 
-
 @interface NewsFeedViewController () <UITableViewDataSource, UITableViewDelegate>
 
 @property (weak, nonatomic) IBOutlet UILabel *userName;
@@ -59,15 +58,17 @@
 }
 
 - (void) updateToPersonalizedNews{
-    NSMutableArray *keywords = [[NSMutableArray alloc] init];
+    NSMutableArray *likedKeywords = [[NSMutableArray alloc] init];
+    NSMutableArray *searchedKeywords = [[NSMutableArray alloc] init];
     [[PFUser query] getFirstObjectInBackgroundWithBlock:^(PFObject *object, NSError *error)
     {
         PFUser *currentUser = [PFUser currentUser];
-        [keywords addObjectsFromArray:[currentUser valueForKey:@"StocksOfInterest"]];
-        NSUInteger rnd = arc4random_uniform((uint32_t)[keywords count]);
-        if (keywords.count > 0) {
-            NSString *key = [keywords objectAtIndex:rnd];
-            if (keywords != nil){
+        [likedKeywords addObjectsFromArray:[currentUser valueForKey:@"StocksOfInterest"]];
+        [searchedKeywords addObjectsFromArray:[currentUser valueForKey:@"SearchedCommodities"]];
+        NSUInteger rnd = arc4random_uniform((uint32_t)[likedKeywords count]);
+        if (likedKeywords.count > 0) {
+            NSString *key = [likedKeywords objectAtIndex:rnd];
+            if (likedKeywords != nil){
                 [[APIManager shared] fetchHeadlineNews:(NSString *) key completion:^(NSMutableArray *keywordArticles, NSError *error) {
                     if (keywordArticles.count > 0) {
                         for (int i = 0; i < numberOfArticles; i++){

--- a/ViewControllers/StockDetailsViewController.m
+++ b/ViewControllers/StockDetailsViewController.m
@@ -28,6 +28,8 @@
 @property (weak, nonatomic) IBOutlet UILabel *bidSize;
 @property (weak, nonatomic) IBOutlet UIScrollView *scrollView;
 @property (weak, nonatomic) IBOutlet UITapGestureRecognizer *scrollVew;
+@property (nonatomic, strong) NSDate *viewSessionStart;
+@property (nonatomic, strong) NSDate *viewSessionEnd;
 
 @end
 
@@ -78,6 +80,24 @@
 
     [alert addAction:defaultAction];
     [self presentViewController:alert animated:YES completion:nil];
+    
+}
+
+- (void)viewDidAppear:(BOOL)animated{
+    self.viewSessionEnd = nil;
+    self.viewSessionStart = [NSDate date];
+}
+
+- (void)viewDidDisappear:(BOOL)animated{
+    self.viewSessionEnd = [NSDate date];
+    NSTimeInterval distanceBetweenDates = [self.viewSessionStart timeIntervalSinceDate:self.viewSessionEnd];
+    NSString *minutesBetweenDates = [NSString stringWithFormat:@"%f", (distanceBetweenDates / 60)];
+    [[PFUser query] getFirstObjectInBackgroundWithBlock:^(PFObject *object, NSError *error) {
+        [[PFUser currentUser] addObject: minutesBetweenDates forKey:@"TimeSpent"];
+        [[PFUser currentUser] addObject: self.stock.ticker forKey:@"TimeSpentTicker"];
+        [[PFUser currentUser] saveInBackground];
+    }];
+    self.viewSessionStart = nil;
     
 }
 

--- a/ViewControllers/StockFeedViewController.m
+++ b/ViewControllers/StockFeedViewController.m
@@ -90,9 +90,15 @@
 
 - (void)searchApi:(NSString *)searchText{
     self.fetchedStockCache = [[NSMutableArray alloc] init];
-    [[APIManager shared] fetchWatchlist:(NSString *) searchText completion:^(NSMutableArray *keywordArticles, NSError *error) {
-        if (keywordArticles) {
-            [self.fetchedStockCache addObjectsFromArray:keywordArticles];
+    [[APIManager shared] fetchWatchlist:(NSString *) searchText completion:^(NSMutableArray *results, NSError *error) {
+        if (results.count > 0) {
+            // caching search queries that only show results
+            [[PFUser query] getFirstObjectInBackgroundWithBlock:^(PFObject *object, NSError *error) {
+                PFUser *currentUser = [PFUser currentUser];
+                [currentUser addObject:[searchText uppercaseString] forKey:@"SearchedCommodities"];
+                [[PFUser currentUser] saveInBackground];
+            }];
+            [self.fetchedStockCache addObjectsFromArray:results];
         }
         [self.searchTableView reloadData];
     }];

--- a/ViewControllers/WatchListViewController.m
+++ b/ViewControllers/WatchListViewController.m
@@ -11,6 +11,7 @@
 #import "StockCell.h"
 #import "APIManager.h"
 #import "WatchlistTableViewCell.h"
+#import "StockDetailsViewController.h"
 
 @interface WatchListViewController ()<UITableViewDelegate, UITableViewDataSource>
 
@@ -52,6 +53,14 @@
             
         }];
     }];
+}
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    if ([segue.identifier isEqualToString: @"watchlistToDetails"]){
+        StockDetailsViewController *stockDetailsController = [segue destinationViewController];
+        NSIndexPath *index = self.watchListTableView.indexPathForSelectedRow;
+        Stock *dataToPass = self.watchListArray[index.row];
+        stockDetailsController.stock = dataToPass;
+    }
 }
 
 - (nonnull UITableViewCell *)tableView:(nonnull UITableView *)tableView cellForRowAtIndexPath:(nonnull NSIndexPath *)indexPath {


### PR DESCRIPTION
Description 
- Caches user's liked stocks/searched commodities/watchList to utilize in curating news to be put on top of the general business newsfeed for the user's delight in reading about relevant commodities/markets. 

Test Plan 
- Observe as the screen refreshes

https://user-images.githubusercontent.com/78214344/183501605-f184f943-8d57-4fea-8302-a3126819fd36.mov

